### PR TITLE
Add alt tags to remaining img elements

### DIFF
--- a/Lesson2/Project/Start/index.html
+++ b/Lesson2/Project/Start/index.html
@@ -109,7 +109,7 @@
           <span class="weather__location">Brighton, UK</span>
           <span class="weather__desc">Sunny</span>
           <span class="weather__today">
-          <img class="weather__today__image" src="images/weather.png" alt="icon of a sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
+          <img class="weather__today__image" src="images/weather.png" alt="icon of a partially sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
           </span>
           <ul class="weather__next">
             <li class="weather__next__item">

--- a/Lesson2/Project/Start/index.html
+++ b/Lesson2/Project/Start/index.html
@@ -109,28 +109,28 @@
           <span class="weather__location">Brighton, UK</span>
           <span class="weather__desc">Sunny</span>
           <span class="weather__today">
-          <img class="weather__today__image" src="images/weather.png"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
+          <img class="weather__today__image" src="images/weather.png" alt="icon of a sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
           </span>
           <ul class="weather__next">
             <li class="weather__next__item">
               <span>Mon</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Tues</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Wed</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Thu</span>
-              <img class="weather__next__image" src="images/rain.png">
+              <img class="weather__next__image" src="images/rain.png" alt="icon of a rainy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Fri</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li>
           </ul>
@@ -140,27 +140,27 @@
           <h2 class="news__title">Latest news <a href="#" class="news__more">+ more</a></h2>
           <ul>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Gastropub distillery Marfa farm-to-table</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Organic raw keffiyeh four loko.</a></h3>
               <p>Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Kickstarter art party cronut scenester.</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Squid lomo Kickstarter art party cronut </a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.

--- a/Lesson4/Project/Start/index.html
+++ b/Lesson4/Project/Start/index.html
@@ -110,7 +110,7 @@
           <span class="weather__location">Brighton, UK</span>
           <span class="weather__desc">Sunny</span>
           <span class="weather__today">
-          <img class="weather__today__image" src="images/weather.png" alt="icon of a sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
+          <img class="weather__today__image" src="images/weather.png" alt="icon of a partially sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
           </span>
           <ul class="weather__next">
             <li class="weather__next__item">

--- a/Lesson4/Project/Start/index.html
+++ b/Lesson4/Project/Start/index.html
@@ -110,28 +110,28 @@
           <span class="weather__location">Brighton, UK</span>
           <span class="weather__desc">Sunny</span>
           <span class="weather__today">
-          <img class="weather__today__image" src="images/weather.png"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
+          <img class="weather__today__image" src="images/weather.png" alt="icon of a sunny day"><span class="weather__today__temp">13</span><span class="weather__today__deg">&deg;C</span>
           </span>
           <ul class="weather__next">
             <li class="weather__next__item">
               <span>Mon</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Tues</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Wed</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Thu</span>
-              <img class="weather__next__image" src="images/rain.png">
+              <img class="weather__next__image" src="images/rain.png" alt="icon of a rainy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Fri</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li>
           </ul>
@@ -141,27 +141,27 @@
           <h2 class="news__title">Latest news <a href="#" class="news__more">+ more</a></h2>
           <ul>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Gastropub distillery Marfa farm-to-table</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Organic raw keffiyeh four loko.</a></h3>
               <p>Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Kickstarter art party cronut scenester.</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Squid lomo Kickstarter art party cronut </a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.

--- a/Lesson5/Project/Solution/index.html
+++ b/Lesson5/Project/Solution/index.html
@@ -128,23 +128,23 @@
           <ul class="weather__next">
             <li class="weather__next__item">
               <span>Mon</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Tues</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Wed</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Thu</span>
-              <img class="weather__next__image" src="images/rain.png">
+              <img class="weather__next__image" src="images/rain.png" alt="icon of a rainy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Fri</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li>
           </ul>
@@ -156,7 +156,7 @@
             <li class="snippet">
               <h3 class="snippet__title"><a href="#">Gastropub distillery Marfa farm-to-table</a></h3>
               <div class="snippet__thumbnail">
-                <img src='images/dog_small.jpg'>
+                <img src='images/dog_small.jpg' alt="picture of a girl with a large, stuffed dog toy">
               </div>
               <p class="snippet__description">Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.
@@ -164,7 +164,7 @@
             </li>
             <li class="snippet">
               <div class="snippet__thumbnail">
-                <img src='images/dog_small.jpg'>
+                <img src='images/dog_small.jpg' alt="picture of a girl with a large, stuffed dog toy">
               </div>
               <h3 class="snippet__title"><a href="#">Organic raw keffiyeh four loko.</a></h3>
               <p class="snippet__description">Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice loko.
@@ -172,7 +172,7 @@
             </li>
             <li class="snippet">
               <div class="snippet__thumbnail">
-                <img src='images/dog_small.jpg'>
+                <img src='images/dog_small.jpg' alt="picture of a girl with a large, stuffed dog toy">
               </div>
               <h3 class="snippet__title"><a href="#">Kickstarter art party cronut scenester.</a></h3>
               <p class="snippet__description">Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
@@ -181,7 +181,7 @@
             </li>
             <li class="snippet">
               <div class="snippet__thumbnail">
-                <img src='images/dog_small.jpg'>
+                <img src='images/dog_small.jpg' alt="picture of a girl with a large, stuffed dog toy">
               </div>
               <h3 class="snippet__title"><a href="#">Squid lomo Kickstarter art party cronut </a></h3>
               <p class="snippet__description">Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.

--- a/Lesson5/Project/Start/index.html
+++ b/Lesson5/Project/Start/index.html
@@ -127,23 +127,23 @@
           <ul class="weather__next">
             <li class="weather__next__item">
               <span>Mon</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Tues</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Wed</span>
-              <img class="weather__next__image" src="images/cloudy.png">
+              <img class="weather__next__image" src="images/cloudy.png" alt="icon of a cloudy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Thu</span>
-              <img class="weather__next__image" src="images/rain.png">
+              <img class="weather__next__image" src="images/rain.png" alt="icon of a rainy day">
               <span>13 &deg;C</span>
             </li><li class="weather__next__item">
               <span>Fri</span>
-              <img class="weather__next__image" src="images/sunny.png">
+              <img class="weather__next__image" src="images/sunny.png" alt="icon of a sunny day">
               <span>13 &deg;C</span>
             </li>
           </ul>
@@ -153,27 +153,27 @@
           <h2 class="news__title">Latest news <a href="#" class="news__more">+ more</a></h2>
           <ul>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Gastropub distillery Marfa farm-to-table</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Organic raw keffiyeh four loko.</a></h3>
               <p>Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Kickstarter art party cronut scenester.</a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.
               </p>
             </li>
             <li class="snippet">
-              <img class="snippet__thumbnail" src="images/dog.jpg">
+              <img class="snippet__thumbnail" src="images/dog.jpg" alt="picture of a girl with a large, stuffed dog toy">
               <h3 class="snippet__title"><a href="#">Squid lomo Kickstarter art party cronut </a></h3>
               <p>Gastropub distillery Marfa farm-to-table, Etsy Truffaut fingerstache.
               Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko. Squid lomo Kickstarter art party cronut scenester. Organic raw denim Vice keffiyeh four loko.Vice keffiyeh four loko.


### PR DESCRIPTION
Github search did not reveal all the img elements at first, so this adds alt tags to the rest of them.
